### PR TITLE
remove height & border options

### DIFF
--- a/bash/base16-3024.config
+++ b/bash/base16-3024.config
@@ -21,7 +21,6 @@ local color0E='#a16a94'
 local color0F='#cdab53'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-apathy.config
+++ b/bash/base16-apathy.config
@@ -21,7 +21,6 @@ local color0E='#4C963E'
 local color0F='#3E965B'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-ashes.config
+++ b/bash/base16-ashes.config
@@ -21,7 +21,6 @@ local color0E='#C795AE'
 local color0F='#C79595'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-cave-light.config
+++ b/bash/base16-atelier-cave-light.config
@@ -21,7 +21,6 @@ local color0E='#955ae7'
 local color0F='#bf40bf'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-cave.config
+++ b/bash/base16-atelier-cave.config
@@ -21,7 +21,6 @@ local color0E='#955ae7'
 local color0F='#bf40bf'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-dune-light.config
+++ b/bash/base16-atelier-dune-light.config
@@ -21,7 +21,6 @@ local color0E='#b854d4'
 local color0F='#d43552'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-dune.config
+++ b/bash/base16-atelier-dune.config
@@ -21,7 +21,6 @@ local color0E='#b854d4'
 local color0F='#d43552'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-estuary-light.config
+++ b/bash/base16-atelier-estuary-light.config
@@ -21,7 +21,6 @@ local color0E='#5f9182'
 local color0F='#9d6c7c'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-estuary.config
+++ b/bash/base16-atelier-estuary.config
@@ -21,7 +21,6 @@ local color0E='#5f9182'
 local color0F='#9d6c7c'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-forest-light.config
+++ b/bash/base16-atelier-forest-light.config
@@ -21,7 +21,6 @@ local color0E='#6666ea'
 local color0F='#c33ff3'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-forest.config
+++ b/bash/base16-atelier-forest.config
@@ -21,7 +21,6 @@ local color0E='#6666ea'
 local color0F='#c33ff3'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-heath-light.config
+++ b/bash/base16-atelier-heath-light.config
@@ -21,7 +21,6 @@ local color0E='#7b59c0'
 local color0F='#cc33cc'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-heath.config
+++ b/bash/base16-atelier-heath.config
@@ -21,7 +21,6 @@ local color0E='#7b59c0'
 local color0F='#cc33cc'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-lakeside-light.config
+++ b/bash/base16-atelier-lakeside-light.config
@@ -21,7 +21,6 @@ local color0E='#6b6bb8'
 local color0F='#b72dd2'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-lakeside.config
+++ b/bash/base16-atelier-lakeside.config
@@ -21,7 +21,6 @@ local color0E='#6b6bb8'
 local color0F='#b72dd2'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-plateau-light.config
+++ b/bash/base16-atelier-plateau-light.config
@@ -21,7 +21,6 @@ local color0E='#8464c4'
 local color0F='#bd5187'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-plateau.config
+++ b/bash/base16-atelier-plateau.config
@@ -21,7 +21,6 @@ local color0E='#8464c4'
 local color0F='#bd5187'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-savanna-light.config
+++ b/bash/base16-atelier-savanna-light.config
@@ -21,7 +21,6 @@ local color0E='#55859b'
 local color0F='#867469'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-savanna.config
+++ b/bash/base16-atelier-savanna.config
@@ -21,7 +21,6 @@ local color0E='#55859b'
 local color0F='#867469'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-seaside-light.config
+++ b/bash/base16-atelier-seaside-light.config
@@ -21,7 +21,6 @@ local color0E='#ad2bee'
 local color0F='#e619c3'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-seaside.config
+++ b/bash/base16-atelier-seaside.config
@@ -21,7 +21,6 @@ local color0E='#ad2bee'
 local color0F='#e619c3'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-sulphurpool-light.config
+++ b/bash/base16-atelier-sulphurpool-light.config
@@ -21,7 +21,6 @@ local color0E='#6679cc'
 local color0F='#9c637a'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-atelier-sulphurpool.config
+++ b/bash/base16-atelier-sulphurpool.config
@@ -21,7 +21,6 @@ local color0E='#6679cc'
 local color0F='#9c637a'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-bespin.config
+++ b/bash/base16-bespin.config
@@ -21,7 +21,6 @@ local color0E='#9b859d'
 local color0F='#937121'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-brewer.config
+++ b/bash/base16-brewer.config
@@ -21,7 +21,6 @@ local color0E='#756bb1'
 local color0F='#b15928'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-bright.config
+++ b/bash/base16-bright.config
@@ -21,7 +21,6 @@ local color0E='#d381c3'
 local color0F='#be643c'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-brushtrees-dark.config
+++ b/bash/base16-brushtrees-dark.config
@@ -21,7 +21,6 @@ local color0E='#b386b2'
 local color0F='#b39f9f'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-brushtrees.config
+++ b/bash/base16-brushtrees.config
@@ -21,7 +21,6 @@ local color0E='#b386b2'
 local color0F='#b39f9f'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-chalk.config
+++ b/bash/base16-chalk.config
@@ -21,7 +21,6 @@ local color0E='#e1a3ee'
 local color0F='#deaf8f'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-circus.config
+++ b/bash/base16-circus.config
@@ -21,7 +21,6 @@ local color0E='#b888e2'
 local color0F='#b888e2'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-classic-dark.config
+++ b/bash/base16-classic-dark.config
@@ -21,7 +21,6 @@ local color0E='#AA759F'
 local color0F='#8F5536'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-classic-light.config
+++ b/bash/base16-classic-light.config
@@ -21,7 +21,6 @@ local color0E='#AA759F'
 local color0F='#8F5536'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-codeschool.config
+++ b/bash/base16-codeschool.config
@@ -21,7 +21,6 @@ local color0E='#c59820'
 local color0F='#c98344'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-cupcake.config
+++ b/bash/base16-cupcake.config
@@ -21,7 +21,6 @@ local color0E='#BB99B4'
 local color0F='#BAA58C'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-cupertino.config
+++ b/bash/base16-cupertino.config
@@ -21,7 +21,6 @@ local color0E='#a90d91'
 local color0F='#826b28'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-darktooth.config
+++ b/bash/base16-darktooth.config
@@ -21,7 +21,6 @@ local color0E='#8F4673'
 local color0F='#A87322'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-default-dark.config
+++ b/bash/base16-default-dark.config
@@ -21,7 +21,6 @@ local color0E='#ba8baf'
 local color0F='#a16946'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-default-light.config
+++ b/bash/base16-default-light.config
@@ -21,7 +21,6 @@ local color0E='#ba8baf'
 local color0F='#a16946'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-dracula.config
+++ b/bash/base16-dracula.config
@@ -21,7 +21,6 @@ local color0E='#b45bcf'
 local color0F='#00f769'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-eighties.config
+++ b/bash/base16-eighties.config
@@ -21,7 +21,6 @@ local color0E='#cc99cc'
 local color0F='#d27b53'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-embers.config
+++ b/bash/base16-embers.config
@@ -21,7 +21,6 @@ local color0E='#82576D'
 local color0F='#825757'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-flat.config
+++ b/bash/base16-flat.config
@@ -21,7 +21,6 @@ local color0E='#9B59B6'
 local color0F='#be643c'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-github.config
+++ b/bash/base16-github.config
@@ -21,7 +21,6 @@ local color0E='#a71d5d'
 local color0F='#333333'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-google-dark.config
+++ b/bash/base16-google-dark.config
@@ -21,7 +21,6 @@ local color0E='#A36AC7'
 local color0F='#3971ED'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-google-light.config
+++ b/bash/base16-google-light.config
@@ -21,7 +21,6 @@ local color0E='#A36AC7'
 local color0F='#3971ED'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-grayscale-dark.config
+++ b/bash/base16-grayscale-dark.config
@@ -21,7 +21,6 @@ local color0E='#747474'
 local color0F='#5e5e5e'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-grayscale-light.config
+++ b/bash/base16-grayscale-light.config
@@ -21,7 +21,6 @@ local color0E='#747474'
 local color0F='#5e5e5e'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-greenscreen.config
+++ b/bash/base16-greenscreen.config
@@ -21,7 +21,6 @@ local color0E='#00bb00'
 local color0F='#005500'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-gruvbox-dark-hard.config
+++ b/bash/base16-gruvbox-dark-hard.config
@@ -21,7 +21,6 @@ local color0E='#d3869b'
 local color0F='#d65d0e'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-gruvbox-dark-medium.config
+++ b/bash/base16-gruvbox-dark-medium.config
@@ -21,7 +21,6 @@ local color0E='#d3869b'
 local color0F='#d65d0e'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-gruvbox-dark-pale.config
+++ b/bash/base16-gruvbox-dark-pale.config
@@ -21,7 +21,6 @@ local color0E='#d485ad'
 local color0F='#d65d0e'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-gruvbox-dark-soft.config
+++ b/bash/base16-gruvbox-dark-soft.config
@@ -21,7 +21,6 @@ local color0E='#d3869b'
 local color0F='#d65d0e'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-gruvbox-light-hard.config
+++ b/bash/base16-gruvbox-light-hard.config
@@ -21,7 +21,6 @@ local color0E='#8f3f71'
 local color0F='#d65d0e'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-gruvbox-light-medium.config
+++ b/bash/base16-gruvbox-light-medium.config
@@ -21,7 +21,6 @@ local color0E='#8f3f71'
 local color0F='#d65d0e'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-gruvbox-light-soft.config
+++ b/bash/base16-gruvbox-light-soft.config
@@ -21,7 +21,6 @@ local color0E='#8f3f71'
 local color0F='#d65d0e'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-harmonic-dark.config
+++ b/bash/base16-harmonic-dark.config
@@ -21,7 +21,6 @@ local color0E='#bf568b'
 local color0F='#bf5656'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-harmonic-light.config
+++ b/bash/base16-harmonic-light.config
@@ -21,7 +21,6 @@ local color0E='#bf568b'
 local color0F='#bf5656'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-hopscotch.config
+++ b/bash/base16-hopscotch.config
@@ -21,7 +21,6 @@ local color0E='#c85e7c'
 local color0F='#b33508'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-irblack.config
+++ b/bash/base16-irblack.config
@@ -21,7 +21,6 @@ local color0E='#ff73fd'
 local color0F='#b18a3d'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-isotope.config
+++ b/bash/base16-isotope.config
@@ -21,7 +21,6 @@ local color0E='#cc00ff'
 local color0F='#3300ff'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-macintosh.config
+++ b/bash/base16-macintosh.config
@@ -21,7 +21,6 @@ local color0E='#4700a5'
 local color0F='#90713a'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-marrakesh.config
+++ b/bash/base16-marrakesh.config
@@ -21,7 +21,6 @@ local color0E='#8868b3'
 local color0F='#b3588e'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-materia.config
+++ b/bash/base16-materia.config
@@ -21,7 +21,6 @@ local color0E='#82AAFF'
 local color0F='#EC5F67'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-material-darker.config
+++ b/bash/base16-material-darker.config
@@ -21,7 +21,6 @@ local color0E='#C792EA'
 local color0F='#FF5370'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-material-lighter.config
+++ b/bash/base16-material-lighter.config
@@ -21,7 +21,6 @@ local color0E='#7C4DFF'
 local color0F='#E53935'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-material-palenight.config
+++ b/bash/base16-material-palenight.config
@@ -21,7 +21,6 @@ local color0E='#C792EA'
 local color0F='#FF5370'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-material.config
+++ b/bash/base16-material.config
@@ -21,7 +21,6 @@ local color0E='#C792EA'
 local color0F='#FF5370'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-mellow-purple.config
+++ b/bash/base16-mellow-purple.config
@@ -21,7 +21,6 @@ local color0E='#8991bb'
 local color0F='#4d6fff'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-mexico-light.config
+++ b/bash/base16-mexico-light.config
@@ -21,7 +21,6 @@ local color0E='#96609e'
 local color0F='#a16946'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-mocha.config
+++ b/bash/base16-mocha.config
@@ -21,7 +21,6 @@ local color0E='#a89bb9'
 local color0F='#bb9584'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-monokai.config
+++ b/bash/base16-monokai.config
@@ -21,7 +21,6 @@ local color0E='#ae81ff'
 local color0F='#cc6633'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-nord.config
+++ b/bash/base16-nord.config
@@ -21,7 +21,6 @@ local color0E='#A3BE8C'
 local color0F='#B48EAD'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-ocean.config
+++ b/bash/base16-ocean.config
@@ -21,7 +21,6 @@ local color0E='#b48ead'
 local color0F='#ab7967'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-oceanicnext.config
+++ b/bash/base16-oceanicnext.config
@@ -21,7 +21,6 @@ local color0E='#C594C5'
 local color0F='#AB7967'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-one-light.config
+++ b/bash/base16-one-light.config
@@ -21,7 +21,6 @@ local color0E='#a626a4'
 local color0F='#986801'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-onedark.config
+++ b/bash/base16-onedark.config
@@ -21,7 +21,6 @@ local color0E='#c678dd'
 local color0F='#be5046'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-paraiso.config
+++ b/bash/base16-paraiso.config
@@ -21,7 +21,6 @@ local color0E='#815ba4'
 local color0F='#e96ba8'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-phd.config
+++ b/bash/base16-phd.config
@@ -21,7 +21,6 @@ local color0E='#9989cc'
 local color0F='#b08060'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-pico.config
+++ b/bash/base16-pico.config
@@ -21,7 +21,6 @@ local color0E='#ff77a8'
 local color0F='#ffccaa'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-pop.config
+++ b/bash/base16-pop.config
@@ -21,7 +21,6 @@ local color0E='#b31e8d'
 local color0F='#7a2d00'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-porple.config
+++ b/bash/base16-porple.config
@@ -21,7 +21,6 @@ local color0E='#b74989'
 local color0F='#986841'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-railscasts.config
+++ b/bash/base16-railscasts.config
@@ -21,7 +21,6 @@ local color0E='#b6b3eb'
 local color0F='#bc9458'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-rebecca.config
+++ b/bash/base16-rebecca.config
@@ -21,7 +21,6 @@ local color0E='#7aa5ff'
 local color0F='#ff79c6'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-seti.config
+++ b/bash/base16-seti.config
@@ -21,7 +21,6 @@ local color0E='#a074c4'
 local color0F='#8a553f'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-shapeshifter.config
+++ b/bash/base16-shapeshifter.config
@@ -21,7 +21,6 @@ local color0E='#f996e2'
 local color0F='#69542d'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-solarflare.config
+++ b/bash/base16-solarflare.config
@@ -21,7 +21,6 @@ local color0E='#A363D5'
 local color0F='#D73C9A'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-solarized-dark.config
+++ b/bash/base16-solarized-dark.config
@@ -21,7 +21,6 @@ local color0E='#6c71c4'
 local color0F='#d33682'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-solarized-light.config
+++ b/bash/base16-solarized-light.config
@@ -21,7 +21,6 @@ local color0E='#6c71c4'
 local color0F='#d33682'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-spacemacs.config
+++ b/bash/base16-spacemacs.config
@@ -21,7 +21,6 @@ local color0E='#a31db1'
 local color0F='#b03060'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-summerfruit-dark.config
+++ b/bash/base16-summerfruit-dark.config
@@ -21,7 +21,6 @@ local color0E='#AD00A1'
 local color0F='#CC6633'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-summerfruit-light.config
+++ b/bash/base16-summerfruit-light.config
@@ -21,7 +21,6 @@ local color0E='#AD00A1'
 local color0F='#CC6633'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-tomorrow-night.config
+++ b/bash/base16-tomorrow-night.config
@@ -21,7 +21,6 @@ local color0E='#b294bb'
 local color0F='#a3685a'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-tomorrow.config
+++ b/bash/base16-tomorrow.config
@@ -21,7 +21,6 @@ local color0E='#8959a8'
 local color0F='#a3685a'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-tube.config
+++ b/bash/base16-tube.config
@@ -21,7 +21,6 @@ local color0E='#98005d'
 local color0F='#b06110'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-twilight.config
+++ b/bash/base16-twilight.config
@@ -21,7 +21,6 @@ local color0E='#9b859d'
 local color0F='#9b703f'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-unikitty-dark.config
+++ b/bash/base16-unikitty-dark.config
@@ -21,7 +21,6 @@ local color0E='#bb60ea'
 local color0F='#c720ca'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-unikitty-light.config
+++ b/bash/base16-unikitty-light.config
@@ -21,7 +21,6 @@ local color0E='#aa17e6'
 local color0F='#e013d0'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-woodland.config
+++ b/bash/base16-woodland.config
@@ -21,7 +21,6 @@ local color0E='#bb90e2'
 local color0F='#b49368'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-xcode-dusk.config
+++ b/bash/base16-xcode-dusk.config
@@ -21,7 +21,6 @@ local color0E='#B21889'
 local color0F='#C77C48'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/bash/base16-zenburn.config
+++ b/bash/base16-zenburn.config
@@ -21,7 +21,6 @@ local color0E='#dc8cc3'
 local color0F='#000000'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-3024.fish
+++ b/fish/base16-3024.fish
@@ -19,7 +19,6 @@ set -l color0E '#a16a94'
 set -l color0F '#cdab53'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-apathy.fish
+++ b/fish/base16-apathy.fish
@@ -19,7 +19,6 @@ set -l color0E '#4C963E'
 set -l color0F '#3E965B'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-ashes.fish
+++ b/fish/base16-ashes.fish
@@ -19,7 +19,6 @@ set -l color0E '#C795AE'
 set -l color0F '#C79595'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-cave-light.fish
+++ b/fish/base16-atelier-cave-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#955ae7'
 set -l color0F '#bf40bf'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-cave.fish
+++ b/fish/base16-atelier-cave.fish
@@ -19,7 +19,6 @@ set -l color0E '#955ae7'
 set -l color0F '#bf40bf'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-dune-light.fish
+++ b/fish/base16-atelier-dune-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#b854d4'
 set -l color0F '#d43552'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-dune.fish
+++ b/fish/base16-atelier-dune.fish
@@ -19,7 +19,6 @@ set -l color0E '#b854d4'
 set -l color0F '#d43552'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-estuary-light.fish
+++ b/fish/base16-atelier-estuary-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#5f9182'
 set -l color0F '#9d6c7c'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-estuary.fish
+++ b/fish/base16-atelier-estuary.fish
@@ -19,7 +19,6 @@ set -l color0E '#5f9182'
 set -l color0F '#9d6c7c'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-forest-light.fish
+++ b/fish/base16-atelier-forest-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#6666ea'
 set -l color0F '#c33ff3'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-forest.fish
+++ b/fish/base16-atelier-forest.fish
@@ -19,7 +19,6 @@ set -l color0E '#6666ea'
 set -l color0F '#c33ff3'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-heath-light.fish
+++ b/fish/base16-atelier-heath-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#7b59c0'
 set -l color0F '#cc33cc'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-heath.fish
+++ b/fish/base16-atelier-heath.fish
@@ -19,7 +19,6 @@ set -l color0E '#7b59c0'
 set -l color0F '#cc33cc'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-lakeside-light.fish
+++ b/fish/base16-atelier-lakeside-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#6b6bb8'
 set -l color0F '#b72dd2'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-lakeside.fish
+++ b/fish/base16-atelier-lakeside.fish
@@ -19,7 +19,6 @@ set -l color0E '#6b6bb8'
 set -l color0F '#b72dd2'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-plateau-light.fish
+++ b/fish/base16-atelier-plateau-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#8464c4'
 set -l color0F '#bd5187'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-plateau.fish
+++ b/fish/base16-atelier-plateau.fish
@@ -19,7 +19,6 @@ set -l color0E '#8464c4'
 set -l color0F '#bd5187'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-savanna-light.fish
+++ b/fish/base16-atelier-savanna-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#55859b'
 set -l color0F '#867469'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-savanna.fish
+++ b/fish/base16-atelier-savanna.fish
@@ -19,7 +19,6 @@ set -l color0E '#55859b'
 set -l color0F '#867469'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-seaside-light.fish
+++ b/fish/base16-atelier-seaside-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#ad2bee'
 set -l color0F '#e619c3'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-seaside.fish
+++ b/fish/base16-atelier-seaside.fish
@@ -19,7 +19,6 @@ set -l color0E '#ad2bee'
 set -l color0F '#e619c3'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-sulphurpool-light.fish
+++ b/fish/base16-atelier-sulphurpool-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#6679cc'
 set -l color0F '#9c637a'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-atelier-sulphurpool.fish
+++ b/fish/base16-atelier-sulphurpool.fish
@@ -19,7 +19,6 @@ set -l color0E '#6679cc'
 set -l color0F '#9c637a'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-bespin.fish
+++ b/fish/base16-bespin.fish
@@ -19,7 +19,6 @@ set -l color0E '#9b859d'
 set -l color0F '#937121'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-brewer.fish
+++ b/fish/base16-brewer.fish
@@ -19,7 +19,6 @@ set -l color0E '#756bb1'
 set -l color0F '#b15928'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-bright.fish
+++ b/fish/base16-bright.fish
@@ -19,7 +19,6 @@ set -l color0E '#d381c3'
 set -l color0F '#be643c'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-brushtrees-dark.fish
+++ b/fish/base16-brushtrees-dark.fish
@@ -19,7 +19,6 @@ set -l color0E '#b386b2'
 set -l color0F '#b39f9f'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-brushtrees.fish
+++ b/fish/base16-brushtrees.fish
@@ -19,7 +19,6 @@ set -l color0E '#b386b2'
 set -l color0F '#b39f9f'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-chalk.fish
+++ b/fish/base16-chalk.fish
@@ -19,7 +19,6 @@ set -l color0E '#e1a3ee'
 set -l color0F '#deaf8f'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-circus.fish
+++ b/fish/base16-circus.fish
@@ -19,7 +19,6 @@ set -l color0E '#b888e2'
 set -l color0F '#b888e2'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-classic-dark.fish
+++ b/fish/base16-classic-dark.fish
@@ -19,7 +19,6 @@ set -l color0E '#AA759F'
 set -l color0F '#8F5536'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-classic-light.fish
+++ b/fish/base16-classic-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#AA759F'
 set -l color0F '#8F5536'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-codeschool.fish
+++ b/fish/base16-codeschool.fish
@@ -19,7 +19,6 @@ set -l color0E '#c59820'
 set -l color0F '#c98344'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-cupcake.fish
+++ b/fish/base16-cupcake.fish
@@ -19,7 +19,6 @@ set -l color0E '#BB99B4'
 set -l color0F '#BAA58C'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-cupertino.fish
+++ b/fish/base16-cupertino.fish
@@ -19,7 +19,6 @@ set -l color0E '#a90d91'
 set -l color0F '#826b28'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-darktooth.fish
+++ b/fish/base16-darktooth.fish
@@ -19,7 +19,6 @@ set -l color0E '#8F4673'
 set -l color0F '#A87322'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-default-dark.fish
+++ b/fish/base16-default-dark.fish
@@ -19,7 +19,6 @@ set -l color0E '#ba8baf'
 set -l color0F '#a16946'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-default-light.fish
+++ b/fish/base16-default-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#ba8baf'
 set -l color0F '#a16946'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-dracula.fish
+++ b/fish/base16-dracula.fish
@@ -19,7 +19,6 @@ set -l color0E '#b45bcf'
 set -l color0F '#00f769'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-eighties.fish
+++ b/fish/base16-eighties.fish
@@ -19,7 +19,6 @@ set -l color0E '#cc99cc'
 set -l color0F '#d27b53'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-embers.fish
+++ b/fish/base16-embers.fish
@@ -19,7 +19,6 @@ set -l color0E '#82576D'
 set -l color0F '#825757'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-flat.fish
+++ b/fish/base16-flat.fish
@@ -19,7 +19,6 @@ set -l color0E '#9B59B6'
 set -l color0F '#be643c'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-github.fish
+++ b/fish/base16-github.fish
@@ -19,7 +19,6 @@ set -l color0E '#a71d5d'
 set -l color0F '#333333'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-google-dark.fish
+++ b/fish/base16-google-dark.fish
@@ -19,7 +19,6 @@ set -l color0E '#A36AC7'
 set -l color0F '#3971ED'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-google-light.fish
+++ b/fish/base16-google-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#A36AC7'
 set -l color0F '#3971ED'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-grayscale-dark.fish
+++ b/fish/base16-grayscale-dark.fish
@@ -19,7 +19,6 @@ set -l color0E '#747474'
 set -l color0F '#5e5e5e'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-grayscale-light.fish
+++ b/fish/base16-grayscale-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#747474'
 set -l color0F '#5e5e5e'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-greenscreen.fish
+++ b/fish/base16-greenscreen.fish
@@ -19,7 +19,6 @@ set -l color0E '#00bb00'
 set -l color0F '#005500'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-gruvbox-dark-hard.fish
+++ b/fish/base16-gruvbox-dark-hard.fish
@@ -19,7 +19,6 @@ set -l color0E '#d3869b'
 set -l color0F '#d65d0e'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-gruvbox-dark-medium.fish
+++ b/fish/base16-gruvbox-dark-medium.fish
@@ -19,7 +19,6 @@ set -l color0E '#d3869b'
 set -l color0F '#d65d0e'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-gruvbox-dark-pale.fish
+++ b/fish/base16-gruvbox-dark-pale.fish
@@ -19,7 +19,6 @@ set -l color0E '#d485ad'
 set -l color0F '#d65d0e'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-gruvbox-dark-soft.fish
+++ b/fish/base16-gruvbox-dark-soft.fish
@@ -19,7 +19,6 @@ set -l color0E '#d3869b'
 set -l color0F '#d65d0e'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-gruvbox-light-hard.fish
+++ b/fish/base16-gruvbox-light-hard.fish
@@ -19,7 +19,6 @@ set -l color0E '#8f3f71'
 set -l color0F '#d65d0e'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-gruvbox-light-medium.fish
+++ b/fish/base16-gruvbox-light-medium.fish
@@ -19,7 +19,6 @@ set -l color0E '#8f3f71'
 set -l color0F '#d65d0e'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-gruvbox-light-soft.fish
+++ b/fish/base16-gruvbox-light-soft.fish
@@ -19,7 +19,6 @@ set -l color0E '#8f3f71'
 set -l color0F '#d65d0e'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-harmonic-dark.fish
+++ b/fish/base16-harmonic-dark.fish
@@ -19,7 +19,6 @@ set -l color0E '#bf568b'
 set -l color0F '#bf5656'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-harmonic-light.fish
+++ b/fish/base16-harmonic-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#bf568b'
 set -l color0F '#bf5656'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-hopscotch.fish
+++ b/fish/base16-hopscotch.fish
@@ -19,7 +19,6 @@ set -l color0E '#c85e7c'
 set -l color0F '#b33508'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-irblack.fish
+++ b/fish/base16-irblack.fish
@@ -19,7 +19,6 @@ set -l color0E '#ff73fd'
 set -l color0F '#b18a3d'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-isotope.fish
+++ b/fish/base16-isotope.fish
@@ -19,7 +19,6 @@ set -l color0E '#cc00ff'
 set -l color0F '#3300ff'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-macintosh.fish
+++ b/fish/base16-macintosh.fish
@@ -19,7 +19,6 @@ set -l color0E '#4700a5'
 set -l color0F '#90713a'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-marrakesh.fish
+++ b/fish/base16-marrakesh.fish
@@ -19,7 +19,6 @@ set -l color0E '#8868b3'
 set -l color0F '#b3588e'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-materia.fish
+++ b/fish/base16-materia.fish
@@ -19,7 +19,6 @@ set -l color0E '#82AAFF'
 set -l color0F '#EC5F67'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-material-darker.fish
+++ b/fish/base16-material-darker.fish
@@ -19,7 +19,6 @@ set -l color0E '#C792EA'
 set -l color0F '#FF5370'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-material-lighter.fish
+++ b/fish/base16-material-lighter.fish
@@ -19,7 +19,6 @@ set -l color0E '#7C4DFF'
 set -l color0F '#E53935'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-material-palenight.fish
+++ b/fish/base16-material-palenight.fish
@@ -19,7 +19,6 @@ set -l color0E '#C792EA'
 set -l color0F '#FF5370'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-material.fish
+++ b/fish/base16-material.fish
@@ -19,7 +19,6 @@ set -l color0E '#C792EA'
 set -l color0F '#FF5370'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-mellow-purple.fish
+++ b/fish/base16-mellow-purple.fish
@@ -19,7 +19,6 @@ set -l color0E '#8991bb'
 set -l color0F '#4d6fff'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-mexico-light.fish
+++ b/fish/base16-mexico-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#96609e'
 set -l color0F '#a16946'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-mocha.fish
+++ b/fish/base16-mocha.fish
@@ -19,7 +19,6 @@ set -l color0E '#a89bb9'
 set -l color0F '#bb9584'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-monokai.fish
+++ b/fish/base16-monokai.fish
@@ -19,7 +19,6 @@ set -l color0E '#ae81ff'
 set -l color0F '#cc6633'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-nord.fish
+++ b/fish/base16-nord.fish
@@ -19,7 +19,6 @@ set -l color0E '#A3BE8C'
 set -l color0F '#B48EAD'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-ocean.fish
+++ b/fish/base16-ocean.fish
@@ -19,7 +19,6 @@ set -l color0E '#b48ead'
 set -l color0F '#ab7967'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-oceanicnext.fish
+++ b/fish/base16-oceanicnext.fish
@@ -19,7 +19,6 @@ set -l color0E '#C594C5'
 set -l color0F '#AB7967'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-one-light.fish
+++ b/fish/base16-one-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#a626a4'
 set -l color0F '#986801'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-onedark.fish
+++ b/fish/base16-onedark.fish
@@ -19,7 +19,6 @@ set -l color0E '#c678dd'
 set -l color0F '#be5046'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-paraiso.fish
+++ b/fish/base16-paraiso.fish
@@ -19,7 +19,6 @@ set -l color0E '#815ba4'
 set -l color0F '#e96ba8'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-phd.fish
+++ b/fish/base16-phd.fish
@@ -19,7 +19,6 @@ set -l color0E '#9989cc'
 set -l color0F '#b08060'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-pico.fish
+++ b/fish/base16-pico.fish
@@ -19,7 +19,6 @@ set -l color0E '#ff77a8'
 set -l color0F '#ffccaa'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-pop.fish
+++ b/fish/base16-pop.fish
@@ -19,7 +19,6 @@ set -l color0E '#b31e8d'
 set -l color0F '#7a2d00'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-porple.fish
+++ b/fish/base16-porple.fish
@@ -19,7 +19,6 @@ set -l color0E '#b74989'
 set -l color0F '#986841'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-railscasts.fish
+++ b/fish/base16-railscasts.fish
@@ -19,7 +19,6 @@ set -l color0E '#b6b3eb'
 set -l color0F '#bc9458'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-rebecca.fish
+++ b/fish/base16-rebecca.fish
@@ -19,7 +19,6 @@ set -l color0E '#7aa5ff'
 set -l color0F '#ff79c6'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-seti.fish
+++ b/fish/base16-seti.fish
@@ -19,7 +19,6 @@ set -l color0E '#a074c4'
 set -l color0F '#8a553f'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-shapeshifter.fish
+++ b/fish/base16-shapeshifter.fish
@@ -19,7 +19,6 @@ set -l color0E '#f996e2'
 set -l color0F '#69542d'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-solarflare.fish
+++ b/fish/base16-solarflare.fish
@@ -19,7 +19,6 @@ set -l color0E '#A363D5'
 set -l color0F '#D73C9A'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-solarized-dark.fish
+++ b/fish/base16-solarized-dark.fish
@@ -19,7 +19,6 @@ set -l color0E '#6c71c4'
 set -l color0F '#d33682'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-solarized-light.fish
+++ b/fish/base16-solarized-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#6c71c4'
 set -l color0F '#d33682'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-spacemacs.fish
+++ b/fish/base16-spacemacs.fish
@@ -19,7 +19,6 @@ set -l color0E '#a31db1'
 set -l color0F '#b03060'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-summerfruit-dark.fish
+++ b/fish/base16-summerfruit-dark.fish
@@ -19,7 +19,6 @@ set -l color0E '#AD00A1'
 set -l color0F '#CC6633'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-summerfruit-light.fish
+++ b/fish/base16-summerfruit-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#AD00A1'
 set -l color0F '#CC6633'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-tomorrow-night.fish
+++ b/fish/base16-tomorrow-night.fish
@@ -19,7 +19,6 @@ set -l color0E '#b294bb'
 set -l color0F '#a3685a'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-tomorrow.fish
+++ b/fish/base16-tomorrow.fish
@@ -19,7 +19,6 @@ set -l color0E '#8959a8'
 set -l color0F '#a3685a'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-tube.fish
+++ b/fish/base16-tube.fish
@@ -19,7 +19,6 @@ set -l color0E '#98005d'
 set -l color0F '#b06110'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-twilight.fish
+++ b/fish/base16-twilight.fish
@@ -19,7 +19,6 @@ set -l color0E '#9b859d'
 set -l color0F '#9b703f'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-unikitty-dark.fish
+++ b/fish/base16-unikitty-dark.fish
@@ -19,7 +19,6 @@ set -l color0E '#bb60ea'
 set -l color0F '#c720ca'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-unikitty-light.fish
+++ b/fish/base16-unikitty-light.fish
@@ -19,7 +19,6 @@ set -l color0E '#aa17e6'
 set -l color0F '#e013d0'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-woodland.fish
+++ b/fish/base16-woodland.fish
@@ -19,7 +19,6 @@ set -l color0E '#bb90e2'
 set -l color0F '#b49368'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-xcode-dusk.fish
+++ b/fish/base16-xcode-dusk.fish
@@ -19,7 +19,6 @@ set -l color0E '#B21889'
 set -l color0F '#C77C48'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/fish/base16-zenburn.fish
+++ b/fish/base16-zenburn.fish
@@ -19,7 +19,6 @@ set -l color0E '#dc8cc3'
 set -l color0F '#000000'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -21,7 +21,6 @@ local color0E='#{{base0E-hex}}'
 local color0F='#{{base0F-hex}}'
 
 export FZF_DEFAULT_OPTS="
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D

--- a/templates/fish.mustache
+++ b/templates/fish.mustache
@@ -19,7 +19,6 @@ set -l color0E '#{{base0E-hex}}'
 set -l color0F '#{{base0F-hex}}'
 
 set -U FZF_DEFAULT_OPTS "
-  --height 40% --border
   --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D
   --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C
   --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D


### PR DESCRIPTION
My understanding is that this repository is supposed to provide color themes for fzf to match base16 themes. If that's the case then I believe enforcing height & border options is too opinionated. I for one don't like having a border and cannot get around it with the current setup. 

In my zshrc I have: 

```
source $DOTFILES/base16-fzf/bash/$BASE16_THEME.config
export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --reverse --height 80%"
```

Those two lines will pull the base16-fzf theme config, and then append the options that I want. In your case you would have the second line read: 

```
export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --height 40% --border"
```

This allows end users to config non-color options how ever they see fit. Right now it is impossible to override the border flag. This pr fixes that. 