### PR TITLE
Export FZF_DEFAULT_OPTS for fish shell in template (take 2)

### DIFF
--- a/fish/base16-3024.fish
+++ b/fish/base16-3024.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-apathy.fish
+++ b/fish/base16-apathy.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-apprentice.fish
+++ b/fish/base16-apprentice.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-ashes.fish
+++ b/fish/base16-ashes.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-cave-light.fish
+++ b/fish/base16-atelier-cave-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-cave.fish
+++ b/fish/base16-atelier-cave.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-dune-light.fish
+++ b/fish/base16-atelier-dune-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-dune.fish
+++ b/fish/base16-atelier-dune.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-estuary-light.fish
+++ b/fish/base16-atelier-estuary-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-estuary.fish
+++ b/fish/base16-atelier-estuary.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-forest-light.fish
+++ b/fish/base16-atelier-forest-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-forest.fish
+++ b/fish/base16-atelier-forest.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-heath-light.fish
+++ b/fish/base16-atelier-heath-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-heath.fish
+++ b/fish/base16-atelier-heath.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-lakeside-light.fish
+++ b/fish/base16-atelier-lakeside-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-lakeside.fish
+++ b/fish/base16-atelier-lakeside.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-plateau-light.fish
+++ b/fish/base16-atelier-plateau-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-plateau.fish
+++ b/fish/base16-atelier-plateau.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-savanna-light.fish
+++ b/fish/base16-atelier-savanna-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-savanna.fish
+++ b/fish/base16-atelier-savanna.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-seaside-light.fish
+++ b/fish/base16-atelier-seaside-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-seaside.fish
+++ b/fish/base16-atelier-seaside.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-sulphurpool-light.fish
+++ b/fish/base16-atelier-sulphurpool-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atelier-sulphurpool.fish
+++ b/fish/base16-atelier-sulphurpool.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-atlas.fish
+++ b/fish/base16-atlas.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-bespin.fish
+++ b/fish/base16-bespin.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-black-metal-bathory.fish
+++ b/fish/base16-black-metal-bathory.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-black-metal-burzum.fish
+++ b/fish/base16-black-metal-burzum.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-black-metal-dark-funeral.fish
+++ b/fish/base16-black-metal-dark-funeral.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-black-metal-gorgoroth.fish
+++ b/fish/base16-black-metal-gorgoroth.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-black-metal-immortal.fish
+++ b/fish/base16-black-metal-immortal.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-black-metal-khold.fish
+++ b/fish/base16-black-metal-khold.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-black-metal-marduk.fish
+++ b/fish/base16-black-metal-marduk.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-black-metal-mayhem.fish
+++ b/fish/base16-black-metal-mayhem.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-black-metal-nile.fish
+++ b/fish/base16-black-metal-nile.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-black-metal-venom.fish
+++ b/fish/base16-black-metal-venom.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-black-metal.fish
+++ b/fish/base16-black-metal.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-brewer.fish
+++ b/fish/base16-brewer.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-bright.fish
+++ b/fish/base16-bright.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-brogrammer.fish
+++ b/fish/base16-brogrammer.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-brushtrees-dark.fish
+++ b/fish/base16-brushtrees-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-brushtrees.fish
+++ b/fish/base16-brushtrees.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-chalk.fish
+++ b/fish/base16-chalk.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-circus.fish
+++ b/fish/base16-circus.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-classic-dark.fish
+++ b/fish/base16-classic-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-classic-light.fish
+++ b/fish/base16-classic-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-codeschool.fish
+++ b/fish/base16-codeschool.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-colors.fish
+++ b/fish/base16-colors.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-cupcake.fish
+++ b/fish/base16-cupcake.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-cupertino.fish
+++ b/fish/base16-cupertino.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-danqing.fish
+++ b/fish/base16-danqing.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-darcula.fish
+++ b/fish/base16-darcula.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-darkmoss.fish
+++ b/fish/base16-darkmoss.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-darktooth.fish
+++ b/fish/base16-darktooth.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-darkviolet.fish
+++ b/fish/base16-darkviolet.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-decaf.fish
+++ b/fish/base16-decaf.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-default-dark.fish
+++ b/fish/base16-default-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-default-light.fish
+++ b/fish/base16-default-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-dirtysea.fish
+++ b/fish/base16-dirtysea.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-dracula.fish
+++ b/fish/base16-dracula.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-edge-dark.fish
+++ b/fish/base16-edge-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-edge-light.fish
+++ b/fish/base16-edge-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-eighties.fish
+++ b/fish/base16-eighties.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-embers.fish
+++ b/fish/base16-embers.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-equilibrium-dark.fish
+++ b/fish/base16-equilibrium-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-equilibrium-gray-dark.fish
+++ b/fish/base16-equilibrium-gray-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-equilibrium-gray-light.fish
+++ b/fish/base16-equilibrium-gray-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-equilibrium-light.fish
+++ b/fish/base16-equilibrium-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-espresso.fish
+++ b/fish/base16-espresso.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-eva-dim.fish
+++ b/fish/base16-eva-dim.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-eva.fish
+++ b/fish/base16-eva.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-flat.fish
+++ b/fish/base16-flat.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-framer.fish
+++ b/fish/base16-framer.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-fruit-soda.fish
+++ b/fish/base16-fruit-soda.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-gigavolt.fish
+++ b/fish/base16-gigavolt.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-github.fish
+++ b/fish/base16-github.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-google-dark.fish
+++ b/fish/base16-google-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-google-light.fish
+++ b/fish/base16-google-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-grayscale-dark.fish
+++ b/fish/base16-grayscale-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-grayscale-light.fish
+++ b/fish/base16-grayscale-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-greenscreen.fish
+++ b/fish/base16-greenscreen.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-gruvbox-dark-hard.fish
+++ b/fish/base16-gruvbox-dark-hard.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-gruvbox-dark-medium.fish
+++ b/fish/base16-gruvbox-dark-medium.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-gruvbox-dark-pale.fish
+++ b/fish/base16-gruvbox-dark-pale.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-gruvbox-dark-soft.fish
+++ b/fish/base16-gruvbox-dark-soft.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-gruvbox-light-hard.fish
+++ b/fish/base16-gruvbox-light-hard.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-gruvbox-light-medium.fish
+++ b/fish/base16-gruvbox-light-medium.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-gruvbox-light-soft.fish
+++ b/fish/base16-gruvbox-light-soft.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-hardcore.fish
+++ b/fish/base16-hardcore.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-harmonic-dark.fish
+++ b/fish/base16-harmonic-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-harmonic-light.fish
+++ b/fish/base16-harmonic-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-heetch-light.fish
+++ b/fish/base16-heetch-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-heetch.fish
+++ b/fish/base16-heetch.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-helios.fish
+++ b/fish/base16-helios.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-hopscotch.fish
+++ b/fish/base16-hopscotch.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-horizon-dark.fish
+++ b/fish/base16-horizon-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-horizon-light.fish
+++ b/fish/base16-horizon-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-horizon-terminal-dark.fish
+++ b/fish/base16-horizon-terminal-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-horizon-terminal-light.fish
+++ b/fish/base16-horizon-terminal-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-humanoid-dark.fish
+++ b/fish/base16-humanoid-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-humanoid-light.fish
+++ b/fish/base16-humanoid-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-ia-dark.fish
+++ b/fish/base16-ia-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-ia-light.fish
+++ b/fish/base16-ia-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-icy.fish
+++ b/fish/base16-icy.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-irblack.fish
+++ b/fish/base16-irblack.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-isotope.fish
+++ b/fish/base16-isotope.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-kimber.fish
+++ b/fish/base16-kimber.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-macintosh.fish
+++ b/fish/base16-macintosh.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-marrakesh.fish
+++ b/fish/base16-marrakesh.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-materia.fish
+++ b/fish/base16-materia.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-material-darker.fish
+++ b/fish/base16-material-darker.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-material-lighter.fish
+++ b/fish/base16-material-lighter.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-material-palenight.fish
+++ b/fish/base16-material-palenight.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-material-vivid.fish
+++ b/fish/base16-material-vivid.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-material.fish
+++ b/fish/base16-material.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-mellow-purple.fish
+++ b/fish/base16-mellow-purple.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-mexico-light.fish
+++ b/fish/base16-mexico-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-mocha.fish
+++ b/fish/base16-mocha.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-monokai.fish
+++ b/fish/base16-monokai.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-nebula.fish
+++ b/fish/base16-nebula.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-nord.fish
+++ b/fish/base16-nord.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-nova.fish
+++ b/fish/base16-nova.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-ocean.fish
+++ b/fish/base16-ocean.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-oceanicnext.fish
+++ b/fish/base16-oceanicnext.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-one-light.fish
+++ b/fish/base16-one-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-onedark.fish
+++ b/fish/base16-onedark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-outrun-dark.fish
+++ b/fish/base16-outrun-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-papercolor-dark.fish
+++ b/fish/base16-papercolor-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-papercolor-light.fish
+++ b/fish/base16-papercolor-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-paraiso.fish
+++ b/fish/base16-paraiso.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-pasque.fish
+++ b/fish/base16-pasque.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-phd.fish
+++ b/fish/base16-phd.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-pico.fish
+++ b/fish/base16-pico.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-pinky.fish
+++ b/fish/base16-pinky.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-pop.fish
+++ b/fish/base16-pop.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-porple.fish
+++ b/fish/base16-porple.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-qualia.fish
+++ b/fish/base16-qualia.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-railscasts.fish
+++ b/fish/base16-railscasts.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-rebecca.fish
+++ b/fish/base16-rebecca.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-rose-pine-dawn.fish
+++ b/fish/base16-rose-pine-dawn.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-rose-pine-moon.fish
+++ b/fish/base16-rose-pine-moon.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-rose-pine.fish
+++ b/fish/base16-rose-pine.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-sagelight.fish
+++ b/fish/base16-sagelight.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-sakura.fish
+++ b/fish/base16-sakura.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-sandcastle.fish
+++ b/fish/base16-sandcastle.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-seti.fish
+++ b/fish/base16-seti.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-shades-of-purple.fish
+++ b/fish/base16-shades-of-purple.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-shapeshifter.fish
+++ b/fish/base16-shapeshifter.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-silk-dark.fish
+++ b/fish/base16-silk-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-silk-light.fish
+++ b/fish/base16-silk-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-snazzy.fish
+++ b/fish/base16-snazzy.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-solarflare-light.fish
+++ b/fish/base16-solarflare-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-solarflare.fish
+++ b/fish/base16-solarflare.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-solarized-dark.fish
+++ b/fish/base16-solarized-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-solarized-light.fish
+++ b/fish/base16-solarized-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-spacemacs.fish
+++ b/fish/base16-spacemacs.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-summercamp.fish
+++ b/fish/base16-summercamp.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-summerfruit-dark.fish
+++ b/fish/base16-summerfruit-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-summerfruit-light.fish
+++ b/fish/base16-summerfruit-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-synth-midnight-dark.fish
+++ b/fish/base16-synth-midnight-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-synth-midnight-light.fish
+++ b/fish/base16-synth-midnight-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-tango.fish
+++ b/fish/base16-tango.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-tender.fish
+++ b/fish/base16-tender.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-tomorrow-night-eighties.fish
+++ b/fish/base16-tomorrow-night-eighties.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-tomorrow-night.fish
+++ b/fish/base16-tomorrow-night.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-tomorrow.fish
+++ b/fish/base16-tomorrow.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-tube.fish
+++ b/fish/base16-tube.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-twilight.fish
+++ b/fish/base16-twilight.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-unikitty-dark.fish
+++ b/fish/base16-unikitty-dark.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-unikitty-light.fish
+++ b/fish/base16-unikitty-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-vulcan.fish
+++ b/fish/base16-vulcan.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-windows-10-light.fish
+++ b/fish/base16-windows-10-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-windows-10.fish
+++ b/fish/base16-windows-10.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-windows-95-light.fish
+++ b/fish/base16-windows-95-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-windows-95.fish
+++ b/fish/base16-windows-95.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-windows-highcontrast-light.fish
+++ b/fish/base16-windows-highcontrast-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-windows-highcontrast.fish
+++ b/fish/base16-windows-highcontrast.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-windows-nt-light.fish
+++ b/fish/base16-windows-nt-light.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-windows-nt.fish
+++ b/fish/base16-windows-nt.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-woodland.fish
+++ b/fish/base16-woodland.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-xcode-dusk.fish
+++ b/fish/base16-xcode-dusk.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/fish/base16-zenburn.fish
+++ b/fish/base16-zenburn.fish
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"

--- a/templates/fish.mustache
+++ b/templates/fish.mustache
@@ -26,7 +26,7 @@ for arg in (echo $FZF_DEFAULT_OPTS | tr " " "\n")
     end
 end
 
-set -U FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
+set -Ux FZF_DEFAULT_OPTS "$FZF_NON_COLOR_OPTS"\
 " --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
 " --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
 " --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"


### PR DESCRIPTION
The user of #18 looks like they've deleted their account; I'm opening the same PR to take over. 

I broke it into 2 commits:
1. Update the `FZF_DEFAULT_OPTS` template for Fish to export the variable - without this, the variable isn't propagated to fzf as mentioned in the other PR.
2. Run `make all` to build all the fish sources from the updated template. I can remove this commit if necessary - not totally sure from the readme whether this is wanted or not, with the GitHub Action and all.

Thanks for your work! I use it as part of my light/dark mode shell toggles, and it's a real treat in Fish being able to have the themes persist across sessions so easily.