### PR TITLE
 Automatically commit scheduled updates through "base16-project-bot"

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,7 +1,9 @@
-name: Update the repository with the latest base16 colorschemes
+name: Update with the latest base16-project colorschemes
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0" # https://crontab.guru/every-week
+
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -15,11 +17,16 @@ jobs:
       - name: Install pybase16
         run: pip install pybase16-builder
       - name: Fetch the repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Run make
         run: make
       - name: Commit the changes, if any
-        uses: stefanzweifel/git-auto-commit-action@v4.1.1
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update repository with the latest base16 colorschemes
+          commit_message: Update with the latest base16-project colorschemes
           branch: ${{ github.head_ref }}
+          commit_user_name: base16-project-bot
+          commit_user_email: base16themeproject@proton.me
+          commit_author: base16-project-bot <base16themeproject@proton.me>


### PR DESCRIPTION
- Upgrade to actions/checkout@v3
- Use stefanzweifel/git-auto-commit-action@v4 (suggested by them and uses latest v4 version)
- Add ability to manually run github action (could be useful for when we want a new scheme to be built immediately)