### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/fzf
+* @tinted-theming/fzf

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update with the latest base16-project colorschemes
+name: Update with the latest tinted-theming colorschemes
 on:
   workflow_dispatch:
   schedule:
@@ -15,16 +15,16 @@ jobs:
       - name: Fetch the schemes repository
         uses: actions/checkout@v3
         with:
-          repository: base16-project/base16-schemes
+          repository: tinted-theming/base16-schemes
           path: schemes
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update with the latest base16-project colorschemes
+          commit_message: Update with the latest tinted-theming colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Or the above steps represented in shell commands:
 
 ```shell 
 cd /path/to/base16-fzf/../ # This repos parent dir 
-git clone git@github.com:base16-project/base16-builder-go.git
+git clone git@github.com:tinted-theming/base16-builder-go.git
 cd base16-builder-go
 go build ./base16-builder-go/base16-builder-go \
   -template-dir ../base16-fzf
@@ -52,7 +52,7 @@ the information on the GitHub page.
   colorschemes, make changes to the template instead.
 - Please abide by what's requested in the [PR template][4].
 
-[1]: https://github.com/base16-project/base16-builder-go
-[2]: https://github.com/base16-project/base16-schemes
+[1]: https://github.com/tinted-theming/base16-builder-go
+[2]: https://github.com/tinted-theming/base16-schemes
 [3]: .github/workflows/update.yml
 [4]: .github/pull_request_template.md

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 nicodebo
+Copyright (c) 2022 [Tinted Theming](https://github.com/tinted-theming)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ This theme was built with [base16-builder-go][3].
 | ------------------------------- | ----------------------------- | ------------------------- | ---------------------------- |
 | ![base16-fzf-solarized-dark][5] | ![base16-fzf-horizon-dark][6] | ![base16-fzf-tomorrow][7] | ![base16-fzf-oceanicnext][8] |
 
-[1]: https://github.com/base16-project/home
+[1]: https://github.com/tinted-theming/home
 [2]: https://github.com/junegunn/fzf
-[3]: https://github.com/base16-project/base16-builder-go
+[3]: https://github.com/tinted-theming/base16-builder-go
 [4]: .github/workflows/update.yml
 [5]: screenshots/base16-solarized-dark.png
 [6]: screenshots/base16-horizon-dark.png

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,5 +1,6 @@
 # Base16 {{scheme-name}}
-# Author: {{scheme-author}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming)
 
 _gen_fzf_default_opts() {
 

--- a/templates/fish.mustache
+++ b/templates/fish.mustache
@@ -1,5 +1,6 @@
 # Base16 {{scheme-name}}
-# Author: {{scheme-author}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming)
 
 set -l color00 '#{{base00-hex}}'
 set -l color01 '#{{base01-hex}}'


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.