### PR TITLE
Fix bug where ansi.sh overwrites env var instead of appending

### DIFF
--- a/ansi/ansi.sh
+++ b/ansi/ansi.sh
@@ -1,9 +1,10 @@
+#!/usr/bin/env sh
 # Name: ANSI passthrough
 # Author: Tinted Theming (https://github.com/tinted-theming)
-# Description: This adds styling using the terminal's 16 ANSI colors
+# Description: Adds fzf styling using the terminal's 16 ANSI colors
 
-export FZF_DEFAULT_OPTS=" \
- --color=bg:0,fg:7,hl:3\
- --color=bg+:8,fg+:7,hl+:11\
- --color=info:3,border:3,prompt:4\
- --color=pointer:0,marker:9,spinner:9,header:1"
+export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS"\
+" --color=bg:0,fg:7,hl:3"\
+" --color=bg+:8,fg+:7,hl+:11"\
+" --color=info:3,border:3,prompt:4"\
+" --color=pointer:0,marker:9,spinner:9,header:1"


### PR DESCRIPTION
Related: https://github.com/tinted-theming/tinted-fzf/issues/25

Fix bug where ansi.sh overwrites env var instead of appending to it.